### PR TITLE
Enable the RPATH always

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,25 @@ if(NOT CMAKE_CXX_STANDARD MATCHES "14|17|20")
   message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD}")
 endif()
 
+# use, i.e. don't skip the full RPATH for the build tree
+set(CMAKE_SKIP_BUILD_RPATH FALSE)
+
+# when building, don't use the install RPATH already
+# (but later on when installing)
+set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+
+set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+
+# add the automatically determined parts of the RPATH
+# which point to directories outside the build tree to the install RPATH
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+# the RPATH to be used when installing, but only if it's not a system directory
+list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
+if("${isSystemDir}" STREQUAL "-1")
+    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+endif("${isSystemDir}" STREQUAL "-1")
+
 include(CTest)
 
 add_subdirectory(DCHdigi)


### PR DESCRIPTION
`libgenfit2.so` was not being found because the RPATH by default gets set to
empty and since now in the nightlies we don't have every path in
LD_LIBRARY_PATH, then it doesn't find the library. Magic copied from
https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/RPATH-handling,
there is more if you want to make sure it works for MacOS

It can be placed in other places, for example check how it is done in EDM4hep:
https://github.com/key4hep/EDM4hep/blob/master/cmake/EDM4HEPBuild.cmake#L7