### PR TITLE
First version of VTX digitisation for IDEA vertex detector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@ MAKEFLAGS += --no-print-directory
 make:
 	@ mkdir -p build install ; \
 	cd build ; \
-	source /cvmfs/sw-nightlies.hsf.org/key4hep/setup.sh ; \
 	cmake .. -DCMAKE_INSTALL_PREFIX=../install ; \
 	make install -j4 ; \
 	cd .. ; \

--- a/Tracking/test/runGenFitTrackingOnSimplifiedDriftChamber.py
+++ b/Tracking/test/runGenFitTrackingOnSimplifiedDriftChamber.py
@@ -91,32 +91,42 @@ from Configurables import SimG4SaveTrackerHits
 saveDCHsimHitTool = SimG4SaveTrackerHits("saveDCHsimHitTool", readoutNames=["SimplifiedDriftChamberCollection"])
 saveDCHsimHitTool.SimTrackHits.Path = "DC_simTrackerHits"
 
-saveVTXBsimHitTool = SimG4SaveTrackerHits("saveVTXBsimHitTool", readoutNames=["VertexBarrelCollection"])
-saveVTXBsimHitTool.SimTrackHits.Path = "VTXB_simTrackerHits"
+saveVTXIBsimHitTool = SimG4SaveTrackerHits("saveVTXIBsimHitTool", readoutNames=["VTXIBCollection"])
+saveVTXIBsimHitTool.SimTrackHits.Path = "VTXIB_simTrackerHits"
 
-saveVTXEsimHitTool = SimG4SaveTrackerHits("saveVTXEsimHitTool", readoutNames=["VertexEndcapCollection"])
-saveVTXEsimHitTool.SimTrackHits.Path = "VTXE_simTrackerHits"
+saveVTXOBsimHitTool = SimG4SaveTrackerHits("saveVTXOBsimHitTool", readoutNames=["VTXOBCollection"])
+saveVTXOBsimHitTool.SimTrackHits.Path = "VTXOB_simTrackerHits"
+
+saveVTXDsimHitTool = SimG4SaveTrackerHits("saveVTXDsimHitTool", readoutNames=["VTXDCollection"])
+saveVTXDsimHitTool.SimTrackHits.Path = "VTXD_simTrackerHits"
 
 from Configurables import SimG4Alg
 geantsim = SimG4Alg("SimG4Alg",
-                       outputs= [saveVTXBsimHitTool, saveVTXEsimHitTool, saveDCHsimHitTool,
+                       outputs= [saveVTXIBsimHitTool, saveVTXOBsimHitTool, saveVTXDsimHitTool, saveDCHsimHitTool,
                                  #saveHistTool
                        ],
                        eventProvider = particle_converter,
                        OutputLevel = INFO)
 
 # Digitize tracker hits (for now digitization is reconstruction)
-vtxb_reco_hit_name = saveVTXBsimHitTool.SimTrackHits.Path.replace("sim", "reco")
+vtxib_reco_hit_name = saveVTXIBsimHitTool.SimTrackHits.Path.replace("sim", "reco")
 from Configurables import VTXdigitizer
-vtxb_digitizer = VTXdigitizer("VTXBdigitizer",
-    inputSimHits = saveVTXBsimHitTool.SimTrackHits.Path,
-    outputDigiHits = vtxb_reco_hit_name
+vtxib_digitizer = VTXdigitizer("VTXIBdigitizer",
+    inputSimHits = saveVTXIBsimHitTool.SimTrackHits.Path,
+    outputDigiHits = vtxib_reco_hit_name
 )
 
-vtxe_reco_hit_name = saveVTXEsimHitTool.SimTrackHits.Path.replace("sim", "reco")
-vtxe_digitizer = VTXdigitizer("VTXEdigitizer",
-    inputSimHits = saveVTXEsimHitTool.SimTrackHits.Path,
-    outputDigiHits = vtxe_reco_hit_name
+vtxob_reco_hit_name = saveVTXOBsimHitTool.SimTrackHits.Path.replace("sim", "reco")
+from Configurables import VTXdigitizer
+vtxob_digitizer = VTXdigitizer("VTXOBdigitizer",
+    inputSimHits = saveVTXOBsimHitTool.SimTrackHits.Path,
+    outputDigiHits = vtxob_reco_hit_name
+)
+
+vtxd_reco_hit_name = saveVTXDsimHitTool.SimTrackHits.Path.replace("sim", "reco")
+vtxd_digitizer = VTXdigitizer("VTXDdigitizer",
+    inputSimHits = saveVTXDsimHitTool.SimTrackHits.Path,
+    outputDigiHits = vtxd_reco_hit_name
 )
 
 dch_reco_hit_name = saveDCHsimHitTool.SimTrackHits.Path.replace("sim", "reco")
@@ -161,7 +171,7 @@ ApplicationMgr(
               hepmc_converter,
               geantsim,
               vtxb_digitizer,
-              vtxe_digitizer,
+              vtxd_digitizer,
               dch_digitizer,
               genfitter,
               out

--- a/VTXdigi/CMakeLists.txt
+++ b/VTXdigi/CMakeLists.txt
@@ -40,3 +40,6 @@ install(TARGETS ${PackageName}
 )
 
 install(FILES ${scripts} DESTINATION test)
+
+SET(test_name "test_runVTXdigitizer")
+ADD_TEST(NAME t_${test_name} COMMAND k4run test/runVTXdigitizer.py)

--- a/VTXdigi/CMakeLists.txt
+++ b/VTXdigi/CMakeLists.txt
@@ -16,6 +16,7 @@ gaudi_add_module(${PackageName}
   Gaudi::GaudiKernel
   EDM4HEP::edm4hep
   k4FWCore::k4FWCore
+  DD4hep::DDRec
 )
 
 target_include_directories(${PackageName} PUBLIC

--- a/VTXdigi/include/VTXdigitizer.h
+++ b/VTXdigi/include/VTXdigitizer.h
@@ -16,6 +16,9 @@
 
 // DD4HEP
 #include "DD4hep/Detector.h"  // for dd4hep::VolumeManager
+#include "DDRec/Vector3D.h"
+#include "DDRec/SurfaceManager.h"
+
 #include "DDSegmentation/BitFieldCoder.h"
 
 /** @class VTXdigitizer
@@ -50,6 +53,8 @@ private:
   // Output digitized vertex hit collection name
   DataHandle<edm4hep::TrackerHitCollection> m_output_digi_hits{"outputDigiHits", Gaudi::DataHandle::Writer, this};
 
+  // Detector name
+  Gaudi::Property<std::string> m_detectorName{this, "detectorName", "Vertex", "Name of the detector (default: Vertex)"};
   // Detector readout names
   Gaudi::Property<std::string> m_readoutName{this, "readoutName", "VertexBarrelCollection", "Name of the detector readout"};
   // Pointer to the geometry service
@@ -68,8 +73,15 @@ private:
   // t resolution in ns
   FloatProperty m_t_resolution{this, "tResolution", 0.1, "Time resolution [ns]"};
 
+  // Surface manager used to project hits onto sensitive surface with forceHitsOntoSurface argument
+  const dd4hep::rec::SurfaceMap* _map;
+
+  // Option to force hits onto sensitive surface
+  BooleanProperty m_forceHitsOntoSurface{this, "forceHitsOntoSurface", false, "Project hits onto the surface in case they are not yet on the surface (default: false"};
+
   // Random Number Service
   IRndmGenSvc* m_randSvc;
+
   // Gaussian random number generator used for smearing
   Rndm::Numbers m_gauss_x;
   Rndm::Numbers m_gauss_y;

--- a/VTXdigi/include/VTXdigitizer.h
+++ b/VTXdigi/include/VTXdigitizer.h
@@ -3,13 +3,20 @@
 // GAUDI
 #include "Gaudi/Property.h"
 #include "GaudiAlg/GaudiAlgorithm.h"
+#include "GaudiKernel/IRndmGenSvc.h"
+#include "GaudiKernel/RndmGenerators.h"
 
 // K4FWCORE
 #include "k4FWCore/DataHandle.h"
+#include "k4Interface/IGeoSvc.h"
 
 // EDM4HEP
 #include "edm4hep/SimTrackerHitCollection.h"
 #include "edm4hep/TrackerHitCollection.h"
+
+// DD4HEP
+#include "DD4hep/Detector.h"  // for dd4hep::VolumeManager
+#include "DDSegmentation/BitFieldCoder.h"
 
 /** @class VTXdigitizer
  *
@@ -42,4 +49,29 @@ private:
   DataHandle<edm4hep::SimTrackerHitCollection> m_input_sim_hits{"inputSimHits", Gaudi::DataHandle::Reader, this};
   // Output digitized vertex hit collection name
   DataHandle<edm4hep::TrackerHitCollection> m_output_digi_hits{"outputDigiHits", Gaudi::DataHandle::Writer, this};
+
+  // Detector readout names
+  Gaudi::Property<std::string> m_readoutName{this, "readoutName", "VTXDCollection", "Name of the detector readout"};
+  // Pointer to the geometry service
+  ServiceHandle<IGeoSvc> m_geoSvc;
+  // Decoder for the cellID
+  dd4hep::DDSegmentation::BitFieldCoder* m_decoder;
+  // Volume manager to get the physical cell sensitive volume
+  dd4hep::VolumeManager m_volman;
+
+  // x resolution in um
+  FloatProperty m_x_resolution{this, "xResolution", 0.1, "Spatial resolution in the x direction [um] (r-phi direction in barrel, z direction in disks)"};
+
+  // y resolution in um
+  FloatProperty m_y_resolution{this, "yResolution", 0.1, "Spatial resolution in the y direction [um] (r direction in barrel, r-phi direction in disks)"};
+
+  // t resolution in ns
+  FloatProperty m_t_resolution{this, "tResolution", 0.1, "Time resolution [ns]"};
+
+  // Random Number Service
+  IRndmGenSvc* m_randSvc;
+  // Gaussian random number generator used for smearing
+  Rndm::Numbers m_gauss_x;
+  Rndm::Numbers m_gauss_y;
+  Rndm::Numbers m_gauss_t;
 };

--- a/VTXdigi/include/VTXdigitizer.h
+++ b/VTXdigi/include/VTXdigitizer.h
@@ -51,7 +51,7 @@ private:
   DataHandle<edm4hep::TrackerHitCollection> m_output_digi_hits{"outputDigiHits", Gaudi::DataHandle::Writer, this};
 
   // Detector readout names
-  Gaudi::Property<std::string> m_readoutName{this, "readoutName", "VTXDCollection", "Name of the detector readout"};
+  Gaudi::Property<std::string> m_readoutName{this, "readoutName", "VertexBarrelCollection", "Name of the detector readout"};
   // Pointer to the geometry service
   ServiceHandle<IGeoSvc> m_geoSvc;
   // Decoder for the cellID
@@ -73,5 +73,5 @@ private:
   // Gaussian random number generator used for smearing
   Rndm::Numbers m_gauss_x;
   Rndm::Numbers m_gauss_y;
-  Rndm::Numbers m_gauss_t;
+  Rndm::Numbers m_gauss_time;
 };

--- a/VTXdigi/src/VTXdigitizer.cpp
+++ b/VTXdigi/src/VTXdigitizer.cpp
@@ -34,16 +34,16 @@ StatusCode VTXdigitizer::initialize() {
   }
 
   // check if readout exists
-  if (m_geoSvc->lcdd()->readouts().find(m_readoutName) == m_geoSvc->lcdd()->readouts().end()) {
+  if (m_geoSvc->getDetector()->readouts().find(m_readoutName) == m_geoSvc->getDetector()->readouts().end()) {
     error() << "Readout <<" << m_readoutName << ">> does not exist." << endmsg;
     return StatusCode::FAILURE;
   }
 
   // set the cellID decoder
-  m_decoder = m_geoSvc->lcdd()->readout(m_readoutName).idSpec().decoder();
+  m_decoder = m_geoSvc->getDetector()->readout(m_readoutName).idSpec().decoder();
 
   // retrieve the volume manager
-  m_volman = m_geoSvc->lcdd()->volumeManager();
+  m_volman = m_geoSvc->getDetector()->volumeManager();
 
   return StatusCode::SUCCESS;
 }
@@ -130,11 +130,13 @@ StatusCode VTXdigitizer::execute() {
     // Smear the hit in the local sensor coordinates
     double digiHitLocalPosition[3];
     if (m_readoutName == "VTXIBCollection" ||
-        m_readoutName == "VTXOBCollection") {  // In barrel, the sensor box is along y-z
+        m_readoutName == "VTXOBCollection" ||
+        m_readoutName == "VertexBarrelCollection") {  // In barrel, the sensor box is along y-z
       digiHitLocalPosition[0] = simHitLocalPositionVector.x();
       digiHitLocalPosition[1] = simHitLocalPositionVector.y() + m_gauss_x.shoot() * dd4hep::mm;
       digiHitLocalPosition[2] = simHitLocalPositionVector.z() + m_gauss_y.shoot() * dd4hep::mm;
-    } else if (m_readoutName == "VTXDCollection") {  // In the disks, the sensor box is already in x-y
+    } else if (m_readoutName == "VTXDCollection" ||
+               m_readoutName == "VertexEndcapCollection") {  // In the disks, the sensor box is already in x-y
       digiHitLocalPosition[0] = simHitLocalPositionVector.x() + m_gauss_x.shoot() * dd4hep::mm;
       digiHitLocalPosition[1] = simHitLocalPositionVector.y() + m_gauss_y.shoot() * dd4hep::mm;
       digiHitLocalPosition[2] = simHitLocalPositionVector.z();

--- a/VTXdigi/src/VTXdigitizer.cpp
+++ b/VTXdigi/src/VTXdigitizer.cpp
@@ -131,18 +131,20 @@ StatusCode VTXdigitizer::execute() {
     double digiHitLocalPosition[3];
     if (m_readoutName == "VTXIBCollection" ||
         m_readoutName == "VTXOBCollection" ||
-        m_readoutName == "VertexBarrelCollection") {  // In barrel, the sensor box is along y-z
+        m_readoutName == "VertexBarrelCollection" ||
+        m_readoutName == "SiWrapperBCollection") {  // In barrel, the sensor box is along y-z
       digiHitLocalPosition[0] = simHitLocalPositionVector.x();
       digiHitLocalPosition[1] = simHitLocalPositionVector.y() + m_gauss_x.shoot() * dd4hep::mm;
       digiHitLocalPosition[2] = simHitLocalPositionVector.z() + m_gauss_y.shoot() * dd4hep::mm;
     } else if (m_readoutName == "VTXDCollection" ||
-               m_readoutName == "VertexEndcapCollection") {  // In the disks, the sensor box is already in x-y
+               m_readoutName == "VertexEndcapCollection" ||
+               m_readoutName == "SiWrapperDCollection") {  // In the disks, the sensor box is already in x-y
       digiHitLocalPosition[0] = simHitLocalPositionVector.x() + m_gauss_x.shoot() * dd4hep::mm;
       digiHitLocalPosition[1] = simHitLocalPositionVector.y() + m_gauss_y.shoot() * dd4hep::mm;
       digiHitLocalPosition[2] = simHitLocalPositionVector.z();
     } else {
       error()
-          << "VTX readout name (m_readoutName) needs to be either VTXIBCollection, VTXOBCollection or VTXDCollection"
+          << "VTX readout name (m_readoutName) unknown!"
           << endmsg;
       return StatusCode::FAILURE;
     }

--- a/VTXdigi/src/VTXdigitizer.cpp
+++ b/VTXdigi/src/VTXdigitizer.cpp
@@ -1,15 +1,50 @@
 #include "VTXdigitizer.h"
 
+// DD4hep
+#include "DD4hep/Detector.h"
+#include "DDRec/Vector3D.h"
+
 DECLARE_COMPONENT(VTXdigitizer)
 
-VTXdigitizer::VTXdigitizer(const std::string& aName, ISvcLocator* aSvcLoc) : GaudiAlgorithm(aName, aSvcLoc) {
+VTXdigitizer::VTXdigitizer(const std::string& aName, ISvcLocator* aSvcLoc) : GaudiAlgorithm(aName, aSvcLoc), m_geoSvc("GeoSvc", "VTXdigitizer")  {
   declareProperty("inputSimHits", m_input_sim_hits, "Input sim vertex hit collection name");
   declareProperty("outputDigiHits", m_output_digi_hits, "Output digitized vertex hit collection name");
 }
 
 VTXdigitizer::~VTXdigitizer() {}
 
-StatusCode VTXdigitizer::initialize() { return StatusCode::SUCCESS; }
+StatusCode VTXdigitizer::initialize() { 
+  // Initialize random services
+  if (service("RndmGenSvc", m_randSvc).isFailure()) {
+    error() << "Couldn't get RndmGenSvc!" << endmsg;
+    return StatusCode::FAILURE;
+  }
+  if (m_gauss_x.initialize(m_randSvc, Rndm::Gauss(0., m_x_resolution)).isFailure()) {
+    error() << "Couldn't initialize RndmGenSvc!" << endmsg;
+    return StatusCode::FAILURE;
+  }
+  if (m_gauss_y.initialize(m_randSvc, Rndm::Gauss(0., m_y_resolution)).isFailure()) {
+    error() << "Couldn't initialize RndmGenSvc!" << endmsg;
+    return StatusCode::FAILURE;
+  }
+  if (m_gauss_t.initialize(m_randSvc, Rndm::Gauss(0., m_t_resolution)).isFailure()) {
+    error() << "Couldn't initialize RndmGenSvc!" << endmsg;
+    return StatusCode::FAILURE;
+  }
+
+  // check if readout exists
+  if (m_geoSvc->lcdd()->readouts().find(m_readoutName) == m_geoSvc->lcdd()->readouts().end()) {
+    error() << "Readout <<" << m_readoutName << ">> does not exist." << endmsg;
+    return StatusCode::FAILURE;
+  }
+
+  // set the cellID decoder
+  m_decoder = m_geoSvc->lcdd()->readout(m_readoutName).idSpec().decoder();
+  
+  // retrieve the volume manager
+  m_volman = m_geoSvc->lcdd()->volumeManager();
+
+  return StatusCode::SUCCESS; }
 
 StatusCode VTXdigitizer::execute() {
   // Get the input collection with Geant4 hits
@@ -20,8 +55,84 @@ StatusCode VTXdigitizer::execute() {
   edm4hep::TrackerHitCollection* output_digi_hits = m_output_digi_hits.createAndPut();
   for (const auto& input_sim_hit : *input_sim_hits) {
     auto output_digi_hit = output_digi_hits->create();
+
+    warning() << "Test!!!" << endmsg;
+
+
+
+
+    // smear the hit position: need to go in the local frame of the silicon sensor to smear in the direction along/perpendicular to the stave
+
+    // retrieve the cell detElement
+    dd4hep::DDSegmentation::CellID cellID         = input_sim_hit.getCellID();
+    auto                           cellDetElement = m_volman.lookupDetElement(cellID);
+    warning() << "cellID: " << cellID << endmsg;
+
+    // retrieve the sensor          ###### (in DD4hep 1.23 there is no easy way to access the volume daughters we have to pass by detElements, in later versions volumes can be used)
+
+    // // VTXIB
+    // const std::string& sensorDetElementName =
+    //     Form("VTXIB_layer%d_stave_sensors_module%d_sensorMotherVolume%d", m_decoder->get(cellID, "layer"),
+    //           m_decoder->get(cellID, "module"), m_decoder->get(cellID, "sensor"));
+    // warning() << "sensorDetElementName: " << sensorDetElementName << endmsg;
+
+    // VTXD
+    const std::string& sensorDetElementName =
+        Form("VTXD_side%d_layer%d_petal%d_stave%d_sensors_module%d_sensor%d", m_decoder->get(cellID, "side"),
+              m_decoder->get(cellID, "layer"), m_decoder->get(cellID, "petal"), m_decoder->get(cellID, "stave"), m_decoder->get(cellID, "module"), m_decoder->get(cellID, "sensor"));
+    warning() << "sensorDetElementName: " << sensorDetElementName << endmsg;
+
+    // // CLD Barrel
+    // const std::string& sensorDetElementName =
+    //     Form("VTXIB_layer%d_stave_sensors_module%d_sensorMotherVolume%d", m_decoder->get(cellID, "layer"),
+    //           m_decoder->get(cellID, "module"), m_decoder->get(cellID, "sensor"));
+    // warning() << "sensorDetElementName: " << sensorDetElementName << endmsg;    
+
+    dd4hep::DetElement sensorDetElement = cellDetElement; // cellDetElement.child(sensorDetElementName);
+
+    // get the transformation matrix used to place the wire
+    const auto& sensorTransformMatrix = sensorDetElement.nominal().worldTransformation();
+
+    // Retrieve global position in mm and apply unit transformation (translation matrix is tored in cm)
+    double simHitGlobalPosition[3] = {input_sim_hit.getPosition().x * dd4hep::mm,
+                                      input_sim_hit.getPosition().y * dd4hep::mm,
+                                      input_sim_hit.getPosition().z * dd4hep::mm}; // Unit correct for vertex?
+    double simHitLocalPosition[3]  = {0, 0, 0};
+
+    // get the simHit coordinate in cm in the sensor reference frame to be able to apply smearing
+    sensorTransformMatrix.MasterToLocal(simHitGlobalPosition, simHitLocalPosition);
+    debug() << "Cell ID string: " << m_decoder->valueString(cellID) << endmsg;
+    ;
+    debug() << "Global simHit x " << simHitGlobalPosition[0] << " --> Local simHit x " << simHitLocalPosition[0]
+            << " in cm" << endmsg;
+    debug() << "Global simHit y " << simHitGlobalPosition[1] << " --> Local simHit y " << simHitLocalPosition[1]
+            << " in cm" << endmsg;
+    debug() << "Global simHit z " << simHitGlobalPosition[2] << " --> Local simHit z " << simHitLocalPosition[2]
+            << " in cm" << endmsg;
+
+    // build a vector to easily apply smearing of distance to the wire
+    dd4hep::rec::Vector3D simHitLocalPositionVector(simHitLocalPosition[0], simHitLocalPosition[1],
+                                                    simHitLocalPosition[2]);
+
+    // get the smeared distance to the wire (cylindrical coordinate as the smearing should be perpendicular to the wire)
+    double smearedX = simHitLocalPositionVector.x() + m_gauss_x.shoot() * dd4hep::mm;
+    double smearedY = simHitLocalPositionVector.y() + m_gauss_y.shoot() * dd4hep::mm;
+
+    // go back to the global frame
+    double digiHitLocalPosition[3]  = {smearedX, smearedY,
+                                        simHitLocalPositionVector.z()};
+    double digiHitGlobalPosition[3] = {0, 0, 0};
+    sensorTransformMatrix.LocalToMaster(digiHitLocalPosition, digiHitGlobalPosition);
+    
+    // go back to mm
+    edm4hep::Vector3d digiHitGlobalPositionVector(digiHitGlobalPosition[0] / dd4hep::mm,
+                                                  digiHitGlobalPosition[1] / dd4hep::mm,
+                                                  digiHitGlobalPosition[2] / dd4hep::mm);
+
+
+
     output_digi_hit.setEDep(input_sim_hit.getEDep());
-    output_digi_hit.setPosition(input_sim_hit.getPosition());
+    output_digi_hit.setPosition(digiHitGlobalPositionVector);
   }
   return StatusCode::SUCCESS;
 }

--- a/VTXdigi/src/VTXdigitizer.cpp
+++ b/VTXdigi/src/VTXdigitizer.cpp
@@ -6,14 +6,15 @@
 
 DECLARE_COMPONENT(VTXdigitizer)
 
-VTXdigitizer::VTXdigitizer(const std::string& aName, ISvcLocator* aSvcLoc) : GaudiAlgorithm(aName, aSvcLoc), m_geoSvc("GeoSvc", "VTXdigitizer")  {
+VTXdigitizer::VTXdigitizer(const std::string& aName, ISvcLocator* aSvcLoc)
+    : GaudiAlgorithm(aName, aSvcLoc), m_geoSvc("GeoSvc", "VTXdigitizer") {
   declareProperty("inputSimHits", m_input_sim_hits, "Input sim vertex hit collection name");
   declareProperty("outputDigiHits", m_output_digi_hits, "Output digitized vertex hit collection name");
 }
 
 VTXdigitizer::~VTXdigitizer() {}
 
-StatusCode VTXdigitizer::initialize() { 
+StatusCode VTXdigitizer::initialize() {
   // Initialize random services
   if (service("RndmGenSvc", m_randSvc).isFailure()) {
     error() << "Couldn't get RndmGenSvc!" << endmsg;
@@ -40,11 +41,12 @@ StatusCode VTXdigitizer::initialize() {
 
   // set the cellID decoder
   m_decoder = m_geoSvc->lcdd()->readout(m_readoutName).idSpec().decoder();
-  
+
   // retrieve the volume manager
   m_volman = m_geoSvc->lcdd()->volumeManager();
 
-  return StatusCode::SUCCESS; }
+  return StatusCode::SUCCESS;
+}
 
 StatusCode VTXdigitizer::execute() {
   // Get the input collection with Geant4 hits
@@ -59,51 +61,51 @@ StatusCode VTXdigitizer::execute() {
     // smear the hit position: need to go in the local frame of the silicon sensor to smear in the direction along/perpendicular to the stave
 
     // retrieve the cell detElement
-    dd4hep::DDSegmentation::CellID cellID         = input_sim_hit.getCellID();
+    dd4hep::DDSegmentation::CellID cellID = input_sim_hit.getCellID();
     debug() << "Digitisation of " << m_readoutName << ", cellID: " << cellID << endmsg;
 
     //// Leave this for the moment as it could be useful
     // std::string sensorDetElementName = "";
     // if(m_readoutName == "VTXIBCollection"){
     //     sensorDetElementName =
-    //       Form( "VTXIB_layer%d_stave%d_module%d_sensors_sensor%d", 
-    //             m_decoder->get(cellID, "layer"), 
-    //             m_decoder->get(cellID, "stave"), 
-    //             m_decoder->get(cellID, "module"), 
+    //       Form( "VTXIB_layer%d_stave%d_module%d_sensors_sensor%d",
+    //             m_decoder->get(cellID, "layer"),
+    //             m_decoder->get(cellID, "stave"),
+    //             m_decoder->get(cellID, "module"),
     //             m_decoder->get(cellID, "sensor")
     //       );
     // }
     // else if(m_readoutName == "VTXOBCollection"){
     //     sensorDetElementName =
-    //       Form( "VTXOB_layer%d_stave%d_module%d_sensor%d", 
-    //             m_decoder->get(cellID, "layer"), 
-    //             m_decoder->get(cellID, "stave"), 
-    //             m_decoder->get(cellID, "module"), 
+    //       Form( "VTXOB_layer%d_stave%d_module%d_sensor%d",
+    //             m_decoder->get(cellID, "layer"),
+    //             m_decoder->get(cellID, "stave"),
+    //             m_decoder->get(cellID, "module"),
     //             m_decoder->get(cellID, "sensor")
     //       );
     // }
     // else if(m_readoutName == "VTXDCollection"){
     //   sensorDetElementName =
-    //     Form( "VTXD_side%d_layer%d_petal%d_stave%d_sensors_module%d_sensor%d", 
-    //           m_decoder->get(cellID, "side"), 
-    //           m_decoder->get(cellID, "layer"), 
-    //           m_decoder->get(cellID, "petal"), 
-    //           m_decoder->get(cellID, "stave"), 
-    //           m_decoder->get(cellID, "module"), 
+    //     Form( "VTXD_side%d_layer%d_petal%d_stave%d_sensors_module%d_sensor%d",
+    //           m_decoder->get(cellID, "side"),
+    //           m_decoder->get(cellID, "layer"),
+    //           m_decoder->get(cellID, "petal"),
+    //           m_decoder->get(cellID, "stave"),
+    //           m_decoder->get(cellID, "module"),
     //           m_decoder->get(cellID, "sensor")
     //     );
     // }
     // else if(m_readoutName == "VertexBarrelReadout"){ // CLD Barrel
     //   sensorDetElementName =
-    //     Form( "VertexBarrel_layer%d_ladder%d", 
-    //           m_decoder->get(cellID, "layer"), 
+    //     Form( "VertexBarrel_layer%d_ladder%d",
+    //           m_decoder->get(cellID, "layer"),
     //           m_decoder->get(cellID, "module")
     //     );
     // }
 
     // Get transformation matrix of sensor
     const auto& sensorTransformMatrix = m_volman.lookupVolumePlacement(cellID).matrix();
-  
+
     // Retrieve global position in mm and apply unit transformation (translation matrix is stored in cm)
     double simHitGlobalPosition[3] = {input_sim_hit.getPosition().x * dd4hep::mm,
                                       input_sim_hit.getPosition().y * dd4hep::mm,
@@ -127,43 +129,44 @@ StatusCode VTXdigitizer::execute() {
 
     // Smear the hit in the local sensor coordinates
     double digiHitLocalPosition[3];
-    if(m_readoutName=="VTXIBCollection" || m_readoutName=="VTXOBCollection"){ // In barrel, the sensor box is along y-z
+    if (m_readoutName == "VTXIBCollection" ||
+        m_readoutName == "VTXOBCollection") {  // In barrel, the sensor box is along y-z
       digiHitLocalPosition[0] = simHitLocalPositionVector.x();
       digiHitLocalPosition[1] = simHitLocalPositionVector.y() + m_gauss_x.shoot() * dd4hep::mm;
       digiHitLocalPosition[2] = simHitLocalPositionVector.z() + m_gauss_y.shoot() * dd4hep::mm;
-    }
-    else if(m_readoutName == "VTXDCollection"){ // In the disks, the sensor box is already in x-y
+    } else if (m_readoutName == "VTXDCollection") {  // In the disks, the sensor box is already in x-y
       digiHitLocalPosition[0] = simHitLocalPositionVector.x() + m_gauss_x.shoot() * dd4hep::mm;
       digiHitLocalPosition[1] = simHitLocalPositionVector.y() + m_gauss_y.shoot() * dd4hep::mm;
       digiHitLocalPosition[2] = simHitLocalPositionVector.z();
-    }
-    else{
-      error() << "VTX readout name (m_readoutName) needs to be either VTXIBCollection, VTXOBCollection or VTXDCollection" << endmsg;
+    } else {
+      error()
+          << "VTX readout name (m_readoutName) needs to be either VTXIBCollection, VTXOBCollection or VTXDCollection"
+          << endmsg;
       return StatusCode::FAILURE;
     }
 
     // go back to the global frame
     double digiHitGlobalPosition[3] = {0, 0, 0};
     sensorTransformMatrix.LocalToMaster(digiHitLocalPosition, digiHitGlobalPosition);
-    
+
     // go back to mm
     edm4hep::Vector3d digiHitGlobalPositionVector(digiHitGlobalPosition[0] / dd4hep::mm,
                                                   digiHitGlobalPosition[1] / dd4hep::mm,
                                                   digiHitGlobalPosition[2] / dd4hep::mm);
 
-    debug() << "Global digiHit x " << digiHitGlobalPositionVector[0] << " [mm] --> Local digiHit x " << digiHitLocalPosition[0]
-            << " [cm]" << endmsg;
-    debug() << "Global digiHit y " << digiHitGlobalPositionVector[1] << " [mm] --> Local digiHit y " << digiHitLocalPosition[1]
-            << " [cm]" << endmsg;
-    debug() << "Global digiHit z " << digiHitGlobalPositionVector[2] << " [mm] --> Local digiHit z " << digiHitLocalPosition[2]
-            << " [cm]" << endmsg;
+    debug() << "Global digiHit x " << digiHitGlobalPositionVector[0] << " [mm] --> Local digiHit x "
+            << digiHitLocalPosition[0] << " [cm]" << endmsg;
+    debug() << "Global digiHit y " << digiHitGlobalPositionVector[1] << " [mm] --> Local digiHit y "
+            << digiHitLocalPosition[1] << " [cm]" << endmsg;
+    debug() << "Global digiHit z " << digiHitGlobalPositionVector[2] << " [mm] --> Local digiHit z "
+            << digiHitLocalPosition[2] << " [cm]" << endmsg;
     debug() << "Moving to next hit... " << std::endl << endmsg;
 
     output_digi_hit.setEDep(input_sim_hit.getEDep());
     output_digi_hit.setPosition(digiHitGlobalPositionVector);
 
     // Apply time smearing
-    output_digi_hit.setTime( input_sim_hit.getTime() + m_gauss_time.shoot() );
+    output_digi_hit.setTime(input_sim_hit.getTime() + m_gauss_time.shoot());
 
     output_digi_hit.setCellID(cellID);
   }

--- a/VTXdigi/test/runVTXdigitizer.py
+++ b/VTXdigi/test/runVTXdigitizer.py
@@ -20,6 +20,9 @@ innerVertexResolution_y = 0.005 # [mm], assume 5 µm resolution for ARCADIA sens
 outerVertexResolution_x = 0.014 # [mm], assume ATLASPix3 sensor with 50 µm pitch -> 50/sqrt(12) = 14.4 µm resolution
 outerVertexResolution_y = 0.043 # [mm], assume ATLASPix3 sensor with 150 µm pitch -> 150/sqrt(12) = 43.3 µm resolution
 
+siWrapperResolution_x = 0.050 # [mm]
+siWrapperResolution_y = 1.0 # [mm]
+
 from Configurables import GenAlg
 genAlg = GenAlg()
 from Configurables import  MomentumRangeParticleGun
@@ -47,16 +50,13 @@ hepmc_converter.hepmcStatusList = []
 from Configurables import GeoSvc
 geoservice = GeoSvc("GeoSvc")
 # if FCC_DETECTORS is empty, this should use relative path to working directory
-# path_to_detector = os.environ.get("FCCDETECTORS", "")
-# path_to_detector = os.environ.get("FCCDETECTORS", "")
-# print(path_to_detector)
-# detectors_to_use=[
-#                     'FCCee/IDEA/compact/IDEA_o1_v01/FCCee_IDEA_o1_v01.xml',
-#                   ]
+path_to_detector = os.environ.get("K4GEO", "") # Previously used "FCCDETECTORS"
+print(path_to_detector)
+detectors_to_use=[
+                    'FCCee/IDEA/compact/IDEA_o1_v02/IDEA_o1_v02.xml',
+                  ]
 # prefix all xmls with path_to_detector
-# geoservice.detectors = [os.path.join(path_to_detector, _det) for _det in detectors_to_use]
-# geoservice.detectors = ["../lcgeo/FCCee/CLD/compact/CLD_o2_v05/CLD_o2_v05.xml"] # CLD
-geoservice.detectors = ["../lcgeo/FCCee/IDEA/compact/IDEA_o1_v01/IDEA_o1_v01.xml"] # IDEA
+geoservice.detectors = [os.path.join(path_to_detector, _det) for _det in detectors_to_use]
 geoservice.OutputLevel = INFO
 
 # Geant4 service
@@ -97,27 +97,33 @@ particle_converter.GenParticles.Path = genParticlesOutputName
 from Configurables import SimG4SaveTrackerHits
 
 ### CLD
-# SimG4SaveTrackerHitsB = SimG4SaveTrackerHits("SimG4SaveTrackerHitsB", readoutNames=["VertexBarrelCollection"])
+# SimG4SaveTrackerHitsB = SimG4SaveTrackerHits("SimG4SaveTrackerHitsB", readoutName="VertexBarrelCollection")
 # SimG4SaveTrackerHitsB.SimTrackHits.Path = "VTXB_simTrackerHits"
 
-# SimG4SaveTrackerHitsE = SimG4SaveTrackerHits("SimG4SaveTrackerHitsE", readoutNames=["VertexEndcapCollection"])
+# SimG4SaveTrackerHitsE = SimG4SaveTrackerHits("SimG4SaveTrackerHitsE", readoutName="VertexEndcapCollection"
 # SimG4SaveTrackerHitsE.SimTrackHits.Path = "VTXE_simTrackerHits"
 
 
 ### IDEA
-SimG4SaveTrackerHitsIB = SimG4SaveTrackerHits("SimG4SaveTrackerHitsIB", readoutNames=["VTXIBCollection"])
+SimG4SaveTrackerHitsIB = SimG4SaveTrackerHits("SimG4SaveTrackerHitsIB", readoutName="VTXIBCollection")
 SimG4SaveTrackerHitsIB.SimTrackHits.Path = "VTXIB_simTrackerHits"
 
-SimG4SaveTrackerHitsOB = SimG4SaveTrackerHits("SimG4SaveTrackerHitsOB", readoutNames=["VTXOBCollection"])
+SimG4SaveTrackerHitsOB = SimG4SaveTrackerHits("SimG4SaveTrackerHitsOB", readoutName="VTXOBCollection")
 SimG4SaveTrackerHitsOB.SimTrackHits.Path = "VTXOB_simTrackerHits"
 
-SimG4SaveTrackerHitsD = SimG4SaveTrackerHits("SimG4SaveTrackerHitsD", readoutNames=["VTXDCollection"])
+SimG4SaveTrackerHitsD = SimG4SaveTrackerHits("SimG4SaveTrackerHitsD", readoutName="VTXDCollection")
 SimG4SaveTrackerHitsD.SimTrackHits.Path = "VTXD_simTrackerHits"
 
+SimG4SaveTrackerHitsSiWrB = SimG4SaveTrackerHits("SimG4SaveTrackerHitsSiWrB", readoutName="SiWrapperBCollection")
+SimG4SaveTrackerHitsSiWrB.SimTrackHits.Path = "SiWrB_simTrackerHits"
+
+SimG4SaveTrackerHitsSiWrD = SimG4SaveTrackerHits("SimG4SaveTrackerHitsSiWrD", readoutName="SiWrapperDCollection")
+SimG4SaveTrackerHitsSiWrD.SimTrackHits.Path = "SiWrD_simTrackerHits"
 
 from Configurables import SimG4Alg
 geantsim = SimG4Alg("SimG4Alg",
-                       outputs= [SimG4SaveTrackerHitsIB, SimG4SaveTrackerHitsOB, SimG4SaveTrackerHitsD  ## IDEA
+                       outputs= [SimG4SaveTrackerHitsIB, SimG4SaveTrackerHitsOB, SimG4SaveTrackerHitsD,  ## IDEA vertex
+                                #  SimG4SaveTrackerHitsSiWrB, SimG4SaveTrackerHitsSiWrD ## IDEA wrapper
                                  #SimG4SaveTrackerHitsB, SimG4SaveTrackerHitsE  ## CLD
                                  #saveHistTool
                        ],
@@ -179,6 +185,26 @@ vtxd_digitizer = VTXdigitizer("VTXDdigitizer",
     OutputLevel = INFO
 )
 
+# siwrb_digitizer = VTXdigitizer("SiWrBdigitizer",
+#     inputSimHits = SimG4SaveTrackerHitsSiWrB.SimTrackHits.Path,
+#     outputDigiHits = SimG4SaveTrackerHitsSiWrB.SimTrackHits.Path.replace("sim", "digi"),
+#     readoutName = "SiWrapperBCollection",
+#     xResolution = siWrapperResolution_x, # mm, r direction
+#     yResolution = siWrapperResolution_y, # mm, phi direction
+#     tResolution = 0.030, # ns
+#     OutputLevel = INFO
+# )
+
+# siwrd_digitizer = VTXdigitizer("SiWrDdigitizer",
+#     inputSimHits = SimG4SaveTrackerHitsSiWrD.SimTrackHits.Path,
+#     outputDigiHits = SimG4SaveTrackerHitsSiWrD.SimTrackHits.Path.replace("sim", "digi"),
+#     readoutName = "SiWrapperDCollection",
+#     xResolution = siWrapperResolution_x, # mm, r direction
+#     yResolution = siWrapperResolution_y, # mm, phi direction
+#     tResolution = 0.030, # ns
+#     OutputLevel = INFO
+# )
+
 # run the genfit tracking 
 # from Configurables import GenFitter
 # genfitter = GenFitter("GenFitter", inputHits = savetrackertool.SimTrackHits.Path.replace("sim", "digi"), outputTracks = "genfit_tracks") 
@@ -213,11 +239,9 @@ ApplicationMgr(
               genAlg,
               hepmc_converter,
               geantsim,
-            #   vtxb_digitizer,
-            #   vtxe_digitizer,
-              vtxib_digitizer,
-              vtxob_digitizer,
-              vtxd_digitizer,
+            #   vtxb_digitizer,vtxe_digitizer,
+              vtxib_digitizer, vtxob_digitizer, vtxd_digitizer,
+            #   siwrb_digitizer, siwrd_digitizer,
               out
               ],
     EvtSel = 'NONE',

--- a/VTXdigi/test/runVTXdigitizer.py
+++ b/VTXdigi/test/runVTXdigitizer.py
@@ -55,6 +55,7 @@ geoservice = GeoSvc("GeoSvc")
 #                   ]
 # prefix all xmls with path_to_detector
 # geoservice.detectors = [os.path.join(path_to_detector, _det) for _det in detectors_to_use]
+# geoservice.detectors = ["../lcgeo/FCCee/CLD/compact/CLD_o2_v05/CLD_o2_v05.xml"] # CLD
 geoservice.detectors = ["../lcgeo/FCCee/IDEA/compact/IDEA_o1_v01/IDEA_o1_v01.xml"] # IDEA
 geoservice.OutputLevel = INFO
 
@@ -96,27 +97,28 @@ particle_converter.GenParticles.Path = genParticlesOutputName
 from Configurables import SimG4SaveTrackerHits
 
 ### CLD
-# savetrackertool = SimG4SaveTrackerHits("SimG4SaveTrackerHits", readoutName="VertexBarrelCollection")
-# savetrackertool.SimTrackHits.Path = "VTXB_simTrackerHits"
+# SimG4SaveTrackerHitsB = SimG4SaveTrackerHits("SimG4SaveTrackerHitsB", readoutNames=["VertexBarrelCollection"])
+# SimG4SaveTrackerHitsB.SimTrackHits.Path = "VTXB_simTrackerHits"
 
-# savetrackertool = SimG4SaveTrackerHits("SimG4SaveTrackerHits", readoutName="VertexEndcapCollection")
-# savetrackertool.SimTrackHits.Path = "VTXE_simTrackerHits"
+# SimG4SaveTrackerHitsE = SimG4SaveTrackerHits("SimG4SaveTrackerHitsE", readoutNames=["VertexEndcapCollection"])
+# SimG4SaveTrackerHitsE.SimTrackHits.Path = "VTXE_simTrackerHits"
 
 
 ### IDEA
-SimG4SaveTrackerHitsIB = SimG4SaveTrackerHits("SimG4SaveTrackerHitsIB", readoutName="VTXIBCollection")
+SimG4SaveTrackerHitsIB = SimG4SaveTrackerHits("SimG4SaveTrackerHitsIB", readoutNames=["VTXIBCollection"])
 SimG4SaveTrackerHitsIB.SimTrackHits.Path = "VTXIB_simTrackerHits"
 
-SimG4SaveTrackerHitsOB = SimG4SaveTrackerHits("SimG4SaveTrackerHitsOB", readoutName="VTXOBCollection")
+SimG4SaveTrackerHitsOB = SimG4SaveTrackerHits("SimG4SaveTrackerHitsOB", readoutNames=["VTXOBCollection"])
 SimG4SaveTrackerHitsOB.SimTrackHits.Path = "VTXOB_simTrackerHits"
 
-SimG4SaveTrackerHitsD = SimG4SaveTrackerHits("SimG4SaveTrackerHitsD", readoutName="VTXDCollection")
+SimG4SaveTrackerHitsD = SimG4SaveTrackerHits("SimG4SaveTrackerHitsD", readoutNames=["VTXDCollection"])
 SimG4SaveTrackerHitsD.SimTrackHits.Path = "VTXD_simTrackerHits"
 
 
 from Configurables import SimG4Alg
 geantsim = SimG4Alg("SimG4Alg",
-                       outputs= [SimG4SaveTrackerHitsIB, SimG4SaveTrackerHitsOB, SimG4SaveTrackerHitsD
+                       outputs= [SimG4SaveTrackerHitsIB, SimG4SaveTrackerHitsOB, SimG4SaveTrackerHitsD  ## IDEA
+                                 #SimG4SaveTrackerHitsB, SimG4SaveTrackerHitsE  ## CLD
                                  #saveHistTool
                        ],
                        eventProvider=particle_converter,
@@ -124,30 +126,30 @@ geantsim = SimG4Alg("SimG4Alg",
 # Digitize tracker hits
 from Configurables import VTXdigitizer
 
-### For CLD
-# vtx_digitizer = VTXdigitizer("VTXdigitizer",
-#     inputSimHits = savetrackertool.SimTrackHits.Path,
-#     outputDigiHits = savetrackertool.SimTrackHits.Path.replace("sim", "digi"),
+### For CLD. Not working yet, SimG4 doesn't produce hits in CLD vertex yet
+# vtxb_digitizer = VTXdigitizer("VTXBdigitizer",
+#     inputSimHits = SimG4SaveTrackerHitsB.SimTrackHits.Path,
+#     outputDigiHits = SimG4SaveTrackerHitsB.SimTrackHits.Path.replace("sim", "digi"),
 #     readoutName = "VertexBarrelCollection",
 #     xResolution = 0.005, # mm
 #     yResolution = 0.005, # mm
 #     tResolution = 1000, # ns
-#     OutputLevel = INFO
+#     OutputLevel = DEBUG
 # )
 
-# vtx_digitizer = VTXdigitizer("VTXdigitizer",
-#     inputSimHits = savetrackertool.SimTrackHits.Path,
-#     outputDigiHits = savetrackertool.SimTrackHits.Path.replace("sim", "digi"),
+# vtxe_digitizer = VTXdigitizer("VTXEdigitizer",
+#     inputSimHits = SimG4SaveTrackerHitsE.SimTrackHits.Path,
+#     outputDigiHits = SimG4SaveTrackerHitsE.SimTrackHits.Path.replace("sim", "digi"),
 #     readoutName = "VertexEndcapCollection",
 #     xResolution = 0.005, # mm
 #     yResolution = 0.005, # mm
 #     tResolution = 1000, # ns
-#     OutputLevel = INFO
+#     OutputLevel = DEBUG
 # )
 
 
 ### For IDEA
-vtxib_digitizer = VTXdigitizer("VTXdigitizer",
+vtxib_digitizer = VTXdigitizer("VTXIBdigitizer",
     inputSimHits = SimG4SaveTrackerHitsIB.SimTrackHits.Path,
     outputDigiHits = SimG4SaveTrackerHitsIB.SimTrackHits.Path.replace("sim", "digi"),
     readoutName = "VTXIBCollection",
@@ -157,7 +159,7 @@ vtxib_digitizer = VTXdigitizer("VTXdigitizer",
     OutputLevel = INFO
 )
 
-vtxob_digitizer = VTXdigitizer("VTXdigitizer",
+vtxob_digitizer = VTXdigitizer("VTXOBdigitizer",
     inputSimHits = SimG4SaveTrackerHitsOB.SimTrackHits.Path,
     outputDigiHits = SimG4SaveTrackerHitsOB.SimTrackHits.Path.replace("sim", "digi"),
     readoutName = "VTXOBCollection",
@@ -167,7 +169,7 @@ vtxob_digitizer = VTXdigitizer("VTXdigitizer",
     OutputLevel = INFO
 )
 
-vtxd_digitizer = VTXdigitizer("VTXdigitizer",
+vtxd_digitizer = VTXdigitizer("VTXDdigitizer",
     inputSimHits = SimG4SaveTrackerHitsD.SimTrackHits.Path,
     outputDigiHits = SimG4SaveTrackerHitsD.SimTrackHits.Path.replace("sim", "digi"),
     readoutName = "VTXDCollection",
@@ -211,10 +213,11 @@ ApplicationMgr(
               genAlg,
               hepmc_converter,
               geantsim,
-            #   vtx_digitizer,
+            #   vtxb_digitizer,
+            #   vtxe_digitizer,
               vtxib_digitizer,
-            #   vtxob_digitizer,
-            #   vtxd_digitizer,
+              vtxob_digitizer,
+              vtxd_digitizer,
               out
               ],
     EvtSel = 'NONE',


### PR DESCRIPTION
Hi @brieucf

Here is a first version of the digitisaton for the vertex detector/silicon detectors. 
For the moment, it only applies a Gaussian smearing to the hits. I will refine this more over time.

One issue I still have is that I cannot do the digitisation of the various vertex subdetectors simultaneously, when uncommenting all VTXdigitizers ([here](https://github.com/armin-ilg/k4RecTracker/blob/aa306b2786a4a031876c18f860c15df2e15209b2/VTXdigi/test/runVTXdigitizer.py#L216)).

I will also make sure that it works properly with the CLD vertex detector.