### PR TITLE
Add environment for the VTXdigi test

### DIFF
--- a/VTXdigi/CMakeLists.txt
+++ b/VTXdigi/CMakeLists.txt
@@ -43,3 +43,7 @@ install(FILES ${scripts} DESTINATION test)
 
 SET(test_name "test_runVTXdigitizer")
 ADD_TEST(NAME t_${test_name} COMMAND k4run test/runVTXdigitizer.py)
+
+set_property(TEST t_${test_name} APPEND PROPERTY ENVIRONMENT "ROOT_INCLUDE_PATH=$<$<TARGET_EXISTS:podio::podio>:$<TARGET_FILE_DIR:podio::podio>/../include>:$<$<TARGET_EXISTS:EDM4HEP::edm4hep>:$<TARGET_FILE_DIR:EDM4HEP::edm4hep>/../include>:$ENV{ROOT_INCLUDE_PATH}")
+set_property(TEST t_${test_name} APPEND PROPERTY ENVIRONMENT "LD_LIBRARY_PATH=${PROJECT_BINARY_DIR}:${PROJECT_BINARY_DIR}/${CMAKE_PROJECT_NAME}:${PROJECT_BINARY_DIR}/genConfDir/${PackageName}:$<$<TARGET_EXISTS:ROOT::Core>:$<TARGET_FILE_DIR:ROOT::Core>>:$<$<TARGET_EXISTS:EDM4HEP::edm4hep>:$<TARGET_FILE_DIR:EDM4HEP::edm4hep>>:$<$<TARGET_EXISTS:podio::podio>:$<TARGET_FILE_DIR:podio::podio>>:$ENV{LD_LIBRARY_PATH}")
+set_property(TEST t_${test_name} APPEND PROPERTY ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}:${PROJECT_BINARY_DIR}/genConfDir:$ENV{PYTHONPATH}")


### PR DESCRIPTION
This is an example of what it has to be done for fixing issues with CTest not finding VTXdigitizer, for example. It's copied and adapted from k4FWCore, so probably all the paths are not needed. After doing this it runs but I get a different error later: 

``` 
ToolSvc.SimG4Sa...   INFO Hits from readout "VTXIBCollection" will be saved in the collection "VTXIB_simTrackerHits".
ToolSvc.SimG4Sa...   INFO Hits from readout "VTXOBCollection" will be saved in the collection "VTXOB_simTrackerHits".
ToolSvc.SimG4Sa...   INFO Hits from readout "VTXDCollection" will be saved in the collection "VTXD_simTrackerHits".
ToolSvc.SimG4Sa...  ERROR Readout  'readoutName':'SiWrBCollection' not found! Please check tool configuration.  Exiting...
ToolSvc             ERROR Error initializing tool 'ToolSvc.SimG4SaveTrackerHitsSiWrB'
SimG4Alg            ERROR Unable to retrieve the output saving tool PublicToolHandle('SimG4SaveTrackerHits/SimG4SaveTrackerHitsSiWrB')
EventLoopMgr        ERROR Unable to initialize Algorithm: SimG4Alg
ServiceManager      ERROR Unable to initialize Service: EventLoopMgr
ApplicationMgr      ERROR Application Manager Terminated with error code 1
```

Consider having all the tests under `/test` instead of having them each in a different folder; the current approach means the environment will have to be copied in each subfolder while it could be in a single place.